### PR TITLE
Previous check was too careful. Disable only readmode "r"

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -202,6 +202,9 @@ function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, 
                  compress::Bool=false, mmaparrays::Bool=false) where T<:Union{Type{IOStream},Type{MmapIO}}
     exists = isfile(fname)
     if exists
+        if filesize(fname) == 0
+            throw(ArgumentError("File exists but is empty"))
+        end
         rname = realpath(fname)
         if haskey(OPEN_FILES, rname)
             ref = OPEN_FILES[rname]

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -202,8 +202,8 @@ function jldopen(fname::AbstractString, wr::Bool, create::Bool, truncate::Bool, 
                  compress::Bool=false, mmaparrays::Bool=false) where T<:Union{Type{IOStream},Type{MmapIO}}
     exists = isfile(fname)
     if exists
-        if filesize(fname) == 0
-            throw(ArgumentError("File exists but is empty"))
+        if filesize(fname) == 0 && (wr, create, truncate) == (false, false, false)
+            throw(ArgumentError("Cannot read from an empty file"))
         end
         rname = realpath(fname)
         if haskey(OPEN_FILES, rname)

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -107,3 +107,6 @@ lsd = Dict("longstring" => longstring)
 save(fn, lsd)
 @test isequal(load(fn), lsd)  
 
+# Issue #183
+jfn, _ = mktemp()
+@test_throws ArgumentError jldopen(jfn, "r")


### PR DESCRIPTION
@kpamnany ,
I'm sorry, it's me again. My previous "fix" was too conservative.
It is in fact possible to open empy files as long as you don't do it in `"r"` read mode.
Hopefully this time everything works out.
(Can't run all tests on my computer. They fail even if the ones in CI pass.)